### PR TITLE
Support inherited environment variable not found with multiple vars

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -41,9 +41,9 @@ func parseBytes(src []byte, out map[string]string, lookupFn LookupFn) error {
 			value, ok := lookupFn(key)
 			if ok {
 				out[key] = value
-				cutset = left
-				continue
 			}
+			cutset = left
+			continue
 		}
 
 		value, left, err := extractVarValue(left, out, lookupFn)
@@ -227,7 +227,6 @@ func isSpace(r rune) bool {
 	}
 	return false
 }
-
 
 // isNewLine reports whether the rune is a new line character
 func isNewLine(r rune) bool {


### PR DESCRIPTION
Hi!

I have been testing the command `docker compose` with environment variable files and the result differs from Docker and Docker-Compose.

## TL;DR

Inherited environment variable not found is [already implemented](https://github.com/compose-spec/godotenv/blob/master/godotenv_test.go#L584) but does not work when there are other env vars defined. This PR fixes it. :)

## Test

Define a `.env` file with the following:

```
ENV_A
ENV_B=
ENV_C=env_c
```

And a `docker-compose.yml` file:

```yml
services:
  alpine:
    image: alpine
    env_file: .env
```

### Docker

```bash
$ docker run --rm --env-file=.env alpine env
ENV_B=
ENV_C=env_c
```

Here `ENV_A` has not been set and `ENV_B` is set with an empty value.

### Docker-Compose

```bash
$ docker-compose run --rm alpine env
ENV_B=
ENV_C=env_c
```

With Docker-Compose, we get the same outcome as Docker

### Compose

```bash
$ docker compose run --rm alpine env
ENV_C=env_c
ENV_A=ENV_B=
```

Here's where the outcome is quite unexpected: `ENV_A` is set with the value `ENV_B=`.

Compose seems to have a problem with key-only items in `.env` file.

## Fix

After investigation, I ended up finding the issue with `godotenv` which is used by [compose-go](https://github.com/compose-spec/compose-go/blob/master/go.mod#L6) and [docker compose](https://github.com/compose-spec/compose-go/blob/master/go.mod#L6). So I decided to create this PR to fix the compatibility issue.